### PR TITLE
[Fix] common misspelling errors

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -93,7 +93,7 @@ set statusline+=\ %P                            "percent through file
 " highlight statusline cterm=reverse
 
 
-" Seperator
+" Separator
 set fillchars+=vert:│ 
 set fillchars+=stl:─
 set fillchars+=stlnc:─


### PR DESCRIPTION
For reference: https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines